### PR TITLE
Extract accessibility plugin

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,25 @@
+use super::SpeechEvent;
+use bevy::prelude::*;
+
+pub struct DebugPlugin;
+
+impl Plugin for DebugPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_system(keyboard_input);
+    }
+}
+
+/// Shortcut keystrokes in case Deepgram isn't working or or is flaky or the individual cannot
+/// otherwise use the speech feature easily. Also good for debugging.
+fn keyboard_input(keys: Res<Input<KeyCode>>, mut speech_events: EventWriter<SpeechEvent>) {
+    if keys.just_pressed(KeyCode::J) {
+        info!("Sending sugar speech event triggered by key press");
+        speech_events.send(SpeechEvent::Sugar);
+    } else if keys.just_pressed(KeyCode::B) {
+        info!("Sending bridge speech event triggered by key press");
+        speech_events.send(SpeechEvent::Bridge);
+    } else if keys.just_pressed(KeyCode::M) {
+        info!("Sending mentos speech event triggered by key press");
+        speech_events.send(SpeechEvent::Mentos);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 use bevy::prelude::*;
 use heron::prelude::*;
 
+mod debug;
 mod player;
 
+use debug::DebugPlugin;
 use player::{Player, PlayerPlugin};
 
 const X_RESOLUTION: f32 = 640.0;
@@ -109,10 +111,10 @@ fn main() {
     .add_plugins(DefaultPlugins)
     .add_plugin(PhysicsPlugin::default())
     .add_plugin(PlayerPlugin)
+    .add_plugin(DebugPlugin)
     .insert_resource(Gravity::from(Vec3::new(0.0, 0.0, 0.0)))
     .add_startup_system(spawn_wall_tiles)
     .add_startup_system(spawn_lava_tiles)
-    .add_system(keyboard_input)
     .add_startup_system(spawn_blueberry_basket)
     .add_startup_system(spawn_wooden_planks)
     .add_startup_system(spawn_bear)
@@ -141,18 +143,6 @@ fn main() {
     app.run();
 }
 
-fn keyboard_input(keys: Res<Input<KeyCode>>, mut speech_events: EventWriter<SpeechEvent>) {
-    if keys.just_pressed(KeyCode::J) {
-        info!("Sending sugar speech event triggered by key press");
-        speech_events.send(SpeechEvent::Sugar);
-    } else if keys.just_pressed(KeyCode::B) {
-        info!("Sending bridge speech event triggered by key press");
-        speech_events.send(SpeechEvent::Bridge);
-    } else if keys.just_pressed(KeyCode::M) {
-        info!("Sending mentos speech event triggered by key press");
-        speech_events.send(SpeechEvent::Mentos);
-    }
-}
 #[derive(Component)]
 pub(crate) struct BlueberryBasket;
 


### PR DESCRIPTION
## This Commit

Extracts a plugin that encapsulates the logic needed for those who cannot use speech to pass the various levels.

## Why?

Because these are separate/transparent to the rest of the app/systems thanks to the use of the `EventWriter<SpeechEvent>` and can be scuttled away to clean some things up.