### PR TITLE
Move camera spawning/tracking to a `CameraPlugin`

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,0 +1,29 @@
+use bevy::prelude::*;
+
+use crate::{Player, Y_RESOLUTION};
+
+pub struct CameraPlugin;
+
+impl Plugin for CameraPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_startup_system(setup_camera)
+            .add_system(camera_follow_player);
+    }
+}
+
+fn setup_camera(mut commands: Commands) {
+    let mut camera = Camera2dBundle::default();
+    camera.projection.scaling_mode = bevy::render::camera::ScalingMode::FixedVertical(1.0);
+    camera.projection.scale = Y_RESOLUTION / 2.0;
+    commands.spawn_bundle(camera);
+}
+
+fn camera_follow_player(
+    mut camera_query: Query<&mut Transform, (With<Camera>, Without<Player>)>,
+    player_query: Query<&Transform, With<Player>>,
+) {
+    let mut camera = camera_query.single_mut();
+    let player = player_query.single();
+    camera.translation.x = player.translation.x;
+    camera.translation.y = player.translation.y;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
 use bevy::prelude::*;
 use heron::prelude::*;
 
+mod camera;
 mod debug;
 mod player;
 
+use camera::CameraPlugin;
 use debug::DebugPlugin;
 use player::{Player, PlayerPlugin};
 
 const X_RESOLUTION: f32 = 640.0;
-const Y_RESOLUTION: f32 = 480.0;
+pub const Y_RESOLUTION: f32 = 480.0;
 
 // z-values
 const Z_WOODEN_SIGN: f32 = 4.0;
@@ -89,13 +91,6 @@ struct GameState {
     treasure_chest_opened: bool,
 }
 
-fn setup_camera(mut commands: Commands) {
-    let mut camera = Camera2dBundle::default();
-    camera.projection.scaling_mode = bevy::render::camera::ScalingMode::FixedVertical(1.0);
-    camera.projection.scale = Y_RESOLUTION / 2.0;
-    commands.spawn_bundle(camera);
-}
-
 fn main() {
     let mut app = App::new();
 
@@ -112,6 +107,7 @@ fn main() {
     .add_plugin(PhysicsPlugin::default())
     .add_plugin(PlayerPlugin)
     .add_plugin(DebugPlugin)
+    .add_plugin(CameraPlugin)
     .insert_resource(Gravity::from(Vec3::new(0.0, 0.0, 0.0)))
     .add_startup_system(spawn_wall_tiles)
     .add_startup_system(spawn_lava_tiles)
@@ -124,7 +120,6 @@ fn main() {
     .add_startup_system(spawn_treasure_chest)
     .add_startup_system(spawn_wooden_signs)
     .add_system(puzzle_sign_system)
-    .add_startup_system(setup_camera)
     .add_event::<SpeechEvent>()
     .add_system(handle_sugar_said_event)
     .add_system(handle_mentos_said_event)

--- a/src/player.rs
+++ b/src/player.rs
@@ -13,7 +13,6 @@ pub struct PlayerPlugin;
 impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
         app.add_startup_system(spawn_player)
-            .add_system(camera_follow_player)
             .add_system(keyboard_input);
     }
 }
@@ -60,14 +59,4 @@ fn keyboard_input(keys: Res<Input<KeyCode>>, mut query: Query<&mut Velocity, Wit
     } else {
         velocity.linear.x = 0.0;
     }
-}
-
-fn camera_follow_player(
-    mut camera_query: Query<&mut Transform, (With<Camera>, Without<Player>)>,
-    player_query: Query<&Transform, With<Player>>,
-) {
-    let mut camera = camera_query.single_mut();
-    let player = player_query.single();
-    camera.translation.x = player.translation.x;
-    camera.translation.y = player.translation.y;
 }


### PR DESCRIPTION
## This Commit

Extracts a plugin dedicated to spawning the camera and moving it around to follow the player.

## Why?

When I extracted `camera_follow_player` into the `PlayerPlugin` I was actually hesitant and thought that went better in a `CameraPlugin`. Then the `PlayerPlugin` would move the `Player` and the `CameraPlugin` would move the `Camera`. Then I was reviewing [this Bevy Jam submission][0] and saw [this][1] and thought, "Okay, let's pull the trigger on that and see how it goes".

## Note

In that repo their `follow_camera` utility eventually got slurped up into a [`Controllable` component][2] so maybe we get there eventually.

[0]: https://github.com/Louis-Tarvin/Elemental-Sorcerer
[1]: https://github.com/Louis-Tarvin/Elemental-Sorcerer/commit/3b2d535f768f4167dcc798a2f85631b1f574abaf#diff-e73f90ab0f0491e6368341bc6018aad7721ea34aff137e157619a6b75f5b4529R1
[2]: https://github.com/Louis-Tarvin/Elemental-Sorcerer/blob/0007fb23aa25bf9b6d7a5587897739336aaa40ac/src/input.rs#L18