### PR TITLE
Use production Deepgram for WS transcription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,46 +1475,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1535,47 +1499,6 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
-
-[[package]]
-name = "futures-task"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
-
-[[package]]
-name = "futures-util"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1966,18 +1889,19 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jamfest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bevy",
  "crossbeam-channel",
  "fon",
- "futures",
  "heron",
+ "js-sys",
  "pasts",
  "rand",
- "tokio",
- "wasm-sockets",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
  "wavy",
+ "web-sys",
 ]
 
 [[package]]
@@ -2693,12 +2617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,6 +2922,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,29 +3131,6 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
-name = "tokio"
-version = "1.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
-dependencies = [
- "autocfg",
- "num_cpus",
- "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "toml"
@@ -3454,19 +3360,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
-
-[[package]]
-name = "wasm-sockets"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f79197ff5b54945ab40e5fc6337dc8be541e113ff7e13884aa9ffe52c90860"
-dependencies = [
- "js-sys",
- "log",
- "thiserror",
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "wavy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jamfest"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -16,12 +16,11 @@ fon = { version = "0.5", optional = true }
 pasts = { version = "0.7", optional = true }
 wavy = { version = "0.9.1", optional = true }
 
-# async runtime dependencies
-futures = { version = "0.3.21", optional = true }
-tokio = { version = "1.17.0", features = ["macros", "rt", "rt-multi-thread"], optional = true }
-
 # websocket dependencies
-wasm-sockets = { version = "0.2.2", optional = true }
+js-sys = { version = "0.3.60", optional = true }
+serde-wasm-bindgen = { version = "0.4.5", optional = true }
+wasm-bindgen = { version = "0.2.83", optional = true }
+web-sys = { version = "0.3", optional = true, features = ["MessageEvent", "WebSocket"] }
 
 # utility dependencies
 crossbeam-channel = { version = "0.5.4", optional = true }
@@ -29,4 +28,13 @@ crossbeam-channel = { version = "0.5.4", optional = true }
 [features]
 default = ["deepgram"]
 dynamic = ["bevy/dynamic"]
-deepgram = ["fon", "pasts", "wavy", "futures", "crossbeam-channel", "wasm-sockets"]
+deepgram = [
+  "crossbeam-channel",
+  "fon",
+  "js-sys",
+  "pasts",
+  "serde-wasm-bindgen",
+  "wasm-bindgen",
+  "wavy",
+  "web-sys",
+]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ I used the following guide, with some modifications, to build for the web:
 
 https://bevy-cheatbook.github.io/platforms/wasm.html
 
-After which, you can quickly run the game with:
+You'll need a [Console token][console] to authenticate to Deepgram. You'll
+need this supplied as an environment variable when compiling the build so
+it's available in the WASM artifact.
 
-```
-cargo run --target wasm32-unknown-unknown
+> :warning: Do not release with a token you care about since it'll be available
+> to the client.
+
+After which, you can run the game with:
+
+```shell
+DEEPGRAM_API_KEY=YOUR_KEY cargo run --target wasm32-unknown-unknown --release
 ```
 
 The output of that command will give you a local url that you can open
@@ -91,3 +98,5 @@ zip -r jamfest.zip out/
 And finally, `jamfest.zip` can be uploaded to itch.io.
 
 The game currently only supports WASM builds, but we can re-add desktop support pretty easily.
+
+[console]: https://console.deepgram.com/signup?jump=keys

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,7 +663,7 @@ fn spawn_lava_tiles_non_collidable(commands: &mut Commands, asset_server: &Res<A
     for coordinate in coordinates {
         spawn_lava_tile_non_collidable(
             commands,
-            &asset_server,
+            asset_server,
             Transform::from_xyz(
                 coordinate.0 as f32 * 16.0,
                 coordinate.1 as f32 * 16.0,

--- a/src/microphone.rs
+++ b/src/microphone.rs
@@ -3,14 +3,25 @@ use bevy::prelude::*;
 
 use fon::{mono::Mono32, Audio, Frame};
 use pasts::exec;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use wavy::{Microphone, MicrophoneStream};
+use web_sys::{MessageEvent, WebSocket};
+
+/// When DG sends us ASR transcripts we'll receive them asynchronously on the `WebSocket`. Those
+/// are then processed and speech events are potentially sent to this receiver that is stored as a
+/// global resource. Systems can then use this resource to consume those messages.
+struct SpeechEventReceiver(crossbeam_channel::Receiver<SpeechEvent>);
 
 pub struct MicrophonePlugin;
+
 impl Plugin for MicrophonePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<MicrophoneReceiver>()
-            .add_startup_system(setup_deepgram.exclusive_system())
-            .add_system(handle_asr);
+            .add_startup_system(connect_to_deepgram.exclusive_system())
+            .add_startup_system(setup_asr_handler)
+            .add_system(proxy_speech_events)
+            .add_system(proxy_audio_to_deepgram);
     }
 }
 
@@ -34,8 +45,14 @@ impl FromWorld for MicrophoneReceiver {
 /// We are using a non-send resource to handle the websocket client.
 /// See more here: https://bevy-cheatbook.github.io/programming/non-send.html
 /// We are also temporarily using a proxy websocket server to handle credentials.
-fn setup_deepgram(world: &mut World) {
-    let client = wasm_sockets::PollingClient::new("wss://spookyspeechspells.deepgram.com/deepgram_websockets_proxy?encoding=linear16&sample_rate=44100&channels=1").unwrap();
+fn connect_to_deepgram(world: &mut World) {
+    let credentials = std::env!("DEEPGRAM_API_KEY");
+    let protocol = vec!["Token", credentials];
+    let client = WebSocket::new_with_str_sequence(
+        "wss://api.deepgram.com/v1/listen?encoding=linear16&sample_rate=44100&channels=1",
+        &serde_wasm_bindgen::to_value(&protocol).unwrap(),
+    )
+    .unwrap();
 
     info!("Connected to Deepgram. Probably.");
 
@@ -48,7 +65,7 @@ fn setup_deepgram(world: &mut World) {
 /// which poll in a bevy system which occurs once per frame ish.
 #[derive(Default)]
 struct DeepgramWebsocket {
-    client: Option<wasm_sockets::PollingClient>,
+    client: Option<WebSocket>,
 }
 
 /// This is based on the following example: https://github.com/libcala/wavy/blob/stable/examples/record/src/main.rs
@@ -126,44 +143,73 @@ pub fn to_vec_u8(input: Vec<i16>) -> Vec<u8> {
     vec_u8
 }
 
-fn handle_asr(
-    microphone_receiver: Res<MicrophoneReceiver>,
+fn setup_asr_handler(
+    mut commands: Commands,
     mut deepgram_websocket: NonSendMut<DeepgramWebsocket>,
-    mut speech_events: EventWriter<SpeechEvent>,
 ) {
     if let Some(client) = &mut deepgram_websocket.client {
-        if client.status() != wasm_sockets::ConnectionStatus::Connected {
+        // We're going to create a closure to receive websocket messages on. We can't just move an
+        // `EventWriter` into that closure to send messages from because the `EventWriter` is tied
+        // to the lifetime of the global `Events` queue and we can't easily communicate that this
+        // closure will outlive that. So instead we create a channel pair and push messages from
+        // the `tx` to the `rx` and then, in a separate system, we read from the `rx` and write to
+        // the `EventWriter`.
+        let (speech_events, rx) = crossbeam_channel::unbounded();
+        let closure = Closure::<dyn FnMut(_)>::new(move |e: MessageEvent| {
+            if let Ok(message) = e.data().dyn_into::<js_sys::JsString>() {
+                trace!("Received a message from Deepgram: {:?}", message);
+                if message.includes("sugar", 0) {
+                    info!("Sending sugar speech event.");
+                    speech_events.send(SpeechEvent::Sugar).unwrap();
+                }
+                if message.includes("mentos", 0) {
+                    info!("Sending mentos speech event.");
+                    speech_events.send(SpeechEvent::Mentos).unwrap();
+                }
+                if message.includes("mentors", 0) {
+                    info!("Sending mentos speech event.");
+                    speech_events.send(SpeechEvent::Mentos).unwrap();
+                }
+                if message.includes("mentor", 0) {
+                    info!("Sending mentos speech event.");
+                    speech_events.send(SpeechEvent::Mentos).unwrap();
+                }
+                if message.includes("bridge", 0) {
+                    info!("Sending bridge speech event.");
+                    speech_events.send(SpeechEvent::Bridge).unwrap();
+                }
+            }
+        });
+        client.set_onmessage(Some(closure.as_ref().unchecked_ref()));
+
+        // We need to forget this on the Rust side. If we didn't then, when this function finished,
+        // the `Closure` object (which is only passed _by reference_ to `set_onmessage`) would also
+        // be dropped. This leaks the closure so that it sticks around and is valid when we later
+        // receive messages on the websocket.
+        closure.forget();
+
+        commands.insert_resource(SpeechEventReceiver(rx));
+    }
+}
+
+fn proxy_audio_to_deepgram(
+    microphone_receiver: Res<MicrophoneReceiver>,
+    mut deepgram_websocket: NonSendMut<DeepgramWebsocket>,
+) {
+    if let Some(client) = &mut deepgram_websocket.client {
+        if client.ready_state() != WebSocket::OPEN {
             return;
         }
 
         while let Ok(audio_buffer) = microphone_receiver.rx.try_recv() {
-            client.send_binary(to_vec_u8(audio_buffer)).unwrap();
-        }
-
-        for message in client.receive() {
-            if let wasm_sockets::Message::Text(message) = message {
-                info!("Received a message from Deepgram: {:?}", message);
-                if message.contains("sugar") {
-                    info!("Sending sugar speech event.");
-                    speech_events.send(SpeechEvent::Sugar);
-                }
-                if message.contains("mentos") {
-                    info!("Sending mentos speech event.");
-                    speech_events.send(SpeechEvent::Mentos);
-                }
-                if message.contains("mentors") {
-                    info!("Sending mentos speech event.");
-                    speech_events.send(SpeechEvent::Mentos);
-                }
-                if message.contains("mentor") {
-                    info!("Sending mentos speech event.");
-                    speech_events.send(SpeechEvent::Mentos);
-                }
-                if message.contains("bridge") {
-                    info!("Sending bridge speech event.");
-                    speech_events.send(SpeechEvent::Bridge);
-                }
-            }
+            client.send_with_u8_array(&to_vec_u8(audio_buffer)).unwrap();
         }
     }
+}
+
+fn proxy_speech_events(
+    speech_event_receiver: ResMut<SpeechEventReceiver>,
+    mut speech_events: EventWriter<SpeechEvent>,
+) {
+    speech_events.send_batch(speech_event_receiver.0.try_iter());
 }


### PR DESCRIPTION
## This Commit

Updates the repo to use the official production Deepgram endpoint for WS transcription instead of the proxy.

## Why?

Because that is more correct and stable. Then we can take down the proxy and stop managing it.

## Notes

This requires those building the repo to compile a token into the binary which will be available on the client. We think this is fine for now and can come up with something else if we want later.